### PR TITLE
Fix #51 - Proper html entity decode and status code verification

### DIFF
--- a/inc/notificationeventwebhook.class.php
+++ b/inc/notificationeventwebhook.class.php
@@ -158,7 +158,7 @@ static public function extraRaise($params) {
 							$key = $webhook_infos[static::getTargetFieldName()];
 							$url = $webhook_infos['additionnaloption']['address']; 
 							$url = NotificationTemplate::process($webhook_infos['additionnaloption']['address'], $data); // substitute variables in url
-							$url = str_replace(["\n", "\r", "\t"], ['', '', ''], htmlentities($url)); // translate HTML-significant characters and suppress remaining escape characters
+							$url = str_replace(["\n", "\r", "\t"], ['', '', ''], html_entity_decode($url)); // translate HTML-significant characters and suppress remaining escape characters
 							if ($template_datas = $template->getByLanguage($webhook_infos['language']))
 							{
 								$template_datas  = Sanitizer::unsanitize($template_datas); // unescape html from DB
@@ -213,7 +213,7 @@ static public function extraRaise($params) {
 
 								$status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-								if ( $status != 200 && $status != 201 ) {
+								if ( $status < 200 || $status >= 300 ) {
 									Session::addMessageAfterRedirect("<font color='red'>"."Error: call to URL $url failed with status $status, response $json_response, curl_error " . curl_error($curl) . ", curl_errno " . curl_errno($curl)."</font>", false, ERROR);
 									Toolbox::logInFile("webhook", "Error : call to URL $url failed with status $status, response $json_response, curl_error " . curl_error($curl) . ", curl_errno " . curl_errno($curl).PHP_EOL."HTTP Headers : ".print_r($headers,true).PHP_EOL."POST Content : ".print_r($content,true).PHP_EOL);
 								}


### PR DESCRIPTION
The previous use of htmlentities($url) was unable to correctly decode ampersand characters, so I replaced it with html_entity_decode.

Moreover, Power Automate responds with a HTTP 202, which was being considered an error by the plugin. I changed the verification for any HTTP status response other than 2xx.