### PR TITLE
Fix #63: Webhook URL encoding causing 403 errors with external APIs

### DIFF
--- a/inc/notificationeventwebhook.class.php
+++ b/inc/notificationeventwebhook.class.php
@@ -158,7 +158,7 @@ static public function extraRaise($params) {
 							$key = $webhook_infos[static::getTargetFieldName()];
 							$url = $webhook_infos['additionnaloption']['address']; 
 							$url = NotificationTemplate::process($webhook_infos['additionnaloption']['address'], $data); // substitute variables in url
-							$url = str_replace(["\n", "\r", "\t"], ['', '', ''], htmlentities($url)); // translate HTML-significant characters and suppress remaining escape characters
+							$url = str_replace(["\n", "\r", "\t"], ['', '', ''], $url); // translate HTML-significant characters and suppress remaining escape characters
 							if ($template_datas = $template->getByLanguage($webhook_infos['language']))
 							{
 								$template_datas  = Sanitizer::unsanitize($template_datas); // unescape html from DB


### PR DESCRIPTION
When configuring a webhook with a URL that includes query parameters (e.g., https://api.example.com/endpoint?param1=value1&param2=value2), the & (ampersand) character is being incorrectly converted to its HTML entity (& or &) before the actual HTTP request is made by the plugin.

This results in external APIs (such as Google Chat's Incoming Webhooks) returning a 403 Permission Denied error, as they do not recognize & as a valid query parameter separator. The API then interprets the key and token parameters incorrectly or as missing.

Error Message Observed:
{ "error": { "code": 403, "message": "The API is called without a valid token. Instructions on how to use incoming webhooks can be found at https://developers.google.com/chat/how-tos/webhooks", "status": "PERMISSION_DENIED" } }
Along with the curl_error showing the URL with &.

Root Cause Analysis:
The issue appears to stem from the htmlentities() function being applied to the webhook URL within the extraRaise method before the curl execution. This function is intended for HTML output sanitization, not for preparing URLs for direct HTTP requests.
The problematic line identified is in:
inc/PluginWebhookNotificationEventWebhook.class.php (approximately line 161, depending on plugin version):
$url = str_replace(["\n", "\r", "\t"], ['', '', ''], htmlentities($url)); // translate HTML-significant characters and suppress remaining escape characters

Steps to Reproduce:

Install and activate the glpi-webhook plugin.

Create an Incoming Webhook in a Google Chat space (or any other API endpoint that uses & for query parameters in its webhook URL). Copy the full webhook URL provided by Google Chat (e.g., https://chat.googleapis.com/v1/spaces/YOUR_SPACE_ID/messages?key=YOUR_KEY&token=YOUR_TOKEN).

In GLPI, navigate to Setup > Notifications > Webhooks (or similar path depending on your GLPI version and plugin setup).

Create a new webhook notification and paste the complete Google Chat webhook URL into the "Address" field.

Configure the webhook to trigger on any event (e.g., "New ticket added").

Trigger the configured event (e.g., create a new ticket).

Observe the GLPI notification logs (via files/_log/webhook.log or GLPI's session messages if error displayed) or monitor the target Google Chat space.

Expected Behavior:
The message should be successfully sent to the Google Chat space.

Actual Behavior:
The webhook fails with a 403 Permission Denied error, and the GLPI logs indicate the curl call was made to a URL where & was replaced by &.

Suggested Fix:
Modify the problematic line in inc/PluginWebhookNotificationEventWebhook.class.php to remove the htmlentities() call:

$url = str_replace(["\n", "\r", "\t"], ['', '', ''], $url); // Removed htmlentities($url)

Environment:

GLPI Version: 10.0.18

Webhook Plugin Version: 1.0.18 (Name: "Webhooks", Install Method: Marketplace)

PHP Version: 8.3.14 (apache2handler)

Operating System: Linux glpi_10 6.14.0-24-generic https://github.com/ericferon/glpi-webhook/issues/24~24.04.3-Ubuntu

Web Server: Apache/2.4.62 (Debian)

Database: MariaDB 10.7.8